### PR TITLE
API fixes

### DIFF
--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -792,14 +792,16 @@ func formatRangeUnified(start, stop int) string {
 
 // Unified diff parameters
 type LineDiffParams struct {
-	A        []string // First sequence lines
-	FromFile string   // First file name
-	FromDate string   // First file time
-	B        []string // Second sequence lines
-	ToFile   string   // Second file name
-	ToDate   string   // Second file time
-	Eol      string   // Headers end of line, defaults to LF
-	Context  int      // Number of context lines
+	A        []string             // First sequence lines
+	FromFile string               // First file name
+	FromDate string               // First file time
+	B        []string             // Second sequence lines
+	ToFile   string               // Second file name
+	ToDate   string               // Second file time
+	Eol      string               // Headers end of line, defaults to LF
+	Context  int                  // Number of context lines
+	AutoJunk bool                 // If true, use autojunking
+	IsJunkLine func(string)bool   // How to spot junk lines
 }
 
 // Compare two sequences of lines; generate the delta as a unified diff.
@@ -841,6 +843,9 @@ func WriteUnifiedDiff(writer io.Writer, diff LineDiffParams) error {
 
 	started := false
 	m := NewMatcher(diff.A, diff.B)
+	if diff.AutoJunk || diff.IsJunkLine != nil {
+		m = NewMatcherWithJunk(diff.A, diff.B, diff.AutoJunk, diff.IsJunkLine)
+	}
 	for _, g := range m.GetGroupedOpCodes(diff.Context) {
 		if !started {
 			started = true
@@ -973,6 +978,9 @@ func WriteContextDiff(writer io.Writer, diff LineDiffParams) error {
 
 	started := false
 	m := NewMatcher(diff.A, diff.B)
+	if diff.AutoJunk || diff.IsJunkLine != nil {
+		m = NewMatcherWithJunk(diff.A, diff.B, diff.AutoJunk, diff.IsJunkLine)
+	}
 	for _, g := range m.GetGroupedOpCodes(diff.Context) {
 		if !started {
 			started = true

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -791,7 +791,7 @@ func formatRangeUnified(start, stop int) string {
 }
 
 // Unified diff parameters
-type UnifiedDiff struct {
+type LineDiffParams struct {
 	A        []string // First sequence lines
 	FromFile string   // First file name
 	FromDate string   // First file time
@@ -821,7 +821,7 @@ type UnifiedDiff struct {
 // times.  Any or all of these may be specified using strings for
 // 'fromfile', 'tofile', 'fromfiledate', and 'tofiledate'.
 // The modification times are normally expressed in the ISO 8601 format.
-func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
+func WriteUnifiedDiff(writer io.Writer, diff LineDiffParams) error {
 	//buf := bufio.NewWriter(writer)
 	//defer buf.Flush()
 	var bld strings.Builder
@@ -902,7 +902,7 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 }
 
 // Like WriteUnifiedDiff but returns the diff a string.
-func GetUnifiedDiffString(diff UnifiedDiff) (string, error) {
+func GetUnifiedDiffString(diff LineDiffParams) (string, error) {
 	w := &bytes.Buffer{}
 	err := WriteUnifiedDiff(w, diff)
 	return string(w.Bytes()), err
@@ -922,7 +922,9 @@ func formatRangeContext(start, stop int) string {
 	return fmt.Sprintf("%d,%d", beginning, beginning+length-1)
 }
 
-type ContextDiff UnifiedDiff
+// For backward compatibility. Ugh.
+type ContextDiff = LineDiffParams
+type UnifiedDiff = LineDiffParams
 
 // Compare two sequences of lines; generate the delta as a context diff.
 //
@@ -1034,7 +1036,7 @@ func GetContextDiffString(diff ContextDiff) (string, error) {
 }
 
 // Split a string on "\n" while preserving them. The output can be used
-// as input for UnifiedDiff and ContextDiff structures.
+// as input for LineDiffParams.
 func SplitLines(s string) []string {
 	lines := strings.SplitAfter(s, "\n")
 	lines[len(lines)-1] += "\n"

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -943,7 +943,7 @@ type UnifiedDiff = LineDiffParams
 // strings for diff.FromFile, diff.ToFile, diff.FromDate, diff.ToDate.
 // The modification times are normally expressed in the ISO 8601 format.
 // If not specified, the strings default to blanks.
-func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
+func WriteContextDiff(writer io.Writer, diff LineDiffParams) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
 	var diffErr error
@@ -1028,8 +1028,8 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 	return diffErr
 }
 
-// Like WriteContextDiff but returns the diff a string.
-func GetContextDiffString(diff ContextDiff) (string, error) {
+// Like WriteContextDiff but returns the diff as a string.
+func GetContextDiffString(diff LineDiffParams) (string, error) {
 	w := &bytes.Buffer{}
 	err := WriteContextDiff(w, diff)
 	return string(w.Bytes()), err

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -121,7 +121,7 @@ fmt.Printf("%s,%T",a,b)`
 one
 three
 four`
-	diff := UnifiedDiff{
+	diff := LineDiffParams{
 		A:        SplitLines(a),
 		B:        SplitLines(b),
 		FromFile: "Original",
@@ -274,7 +274,7 @@ func TestSFBugsRatioForNullSeqn(t *testing.T) {
 func TestSFBugsComparingEmptyLists(t *testing.T) {
 	groups := NewMatcher(nil, nil).GetGroupedOpCodes(-1)
 	assertEqual(t, len(groups), 0)
-	diff := UnifiedDiff{
+	diff := LineDiffParams{
 		FromFile: "Original",
 		ToFile:   "Current",
 		Context:  3,
@@ -326,7 +326,7 @@ func TestOutputFormatRangeFormatContext(t *testing.T) {
 }
 
 func TestOutputFormatTabDelimiter(t *testing.T) {
-	diff := UnifiedDiff{
+	diff := LineDiffParams{
 		A:        splitChars("one"),
 		B:        splitChars("two"),
 		FromFile: "Original",
@@ -350,7 +350,7 @@ func TestOutputFormatTabDelimiter(t *testing.T) {
 }
 
 func TestOutputFormatNoTrailingTabOnEmptyFiledate(t *testing.T) {
-	diff := UnifiedDiff{
+	diff := LineDiffParams{
 		A:        splitChars("one"),
 		B:        splitChars("two"),
 		FromFile: "Original",
@@ -367,7 +367,7 @@ func TestOutputFormatNoTrailingTabOnEmptyFiledate(t *testing.T) {
 }
 
 func TestOmitFilenames(t *testing.T) {
-	diff := UnifiedDiff{
+	diff := LineDiffParams{
 		A:   SplitLines("o\nn\ne\n"),
 		B:   SplitLines("t\nw\no\n"),
 		Eol: "\n",
@@ -600,7 +600,7 @@ func TestGetUnifiedDiffString(t *testing.T) {
 	A := "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n"
 	B := "one\ntwo\nthr33\nfour\nfive\nsix\nseven\neight\nnine\nten\n"
 	// Build diff
-	diff := UnifiedDiff{A: SplitLines(A),
+	diff := LineDiffParams{A: SplitLines(A),
 		FromFile: "file", FromDate: "then",
 		B: SplitLines(B),
 		ToFile: "tile", ToDate: "now", Eol: "", Context: 1}


### PR DESCRIPTION
Rename the parameter block for line-oriented diffing and add twi members to it.

These changes should be backward compatible.