### PR TITLE
Change import of "tester" from relative path to full path

### DIFF
--- a/difflib/bytes/bytes_test.go
+++ b/difflib/bytes/bytes_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 	"sort"
-	"../tester"
+	"github.com/ianbruene/go-difflib/difflib/tester"
 )
 
 func assertAlmostEqual(t *testing.T, a, b float64, places int) {

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"./tester"
+	"github.com/ianbruene/go-difflib/difflib/tester"
 )
 
 func assertAlmostEqual(t *testing.T, a, b float64, places int) {


### PR DESCRIPTION
This solves the "unexpected directory layout" error when `go test` is
called like so: `go test github.com/ianbruene/go-difflib/difflib/...`

This was discovered when packaging github.com/ianbruene/go-difflib as `golang-github-ianbruene-go-difflib` for Debian:

```
   dh_auto_test -O--builddirectory=_build -O--buildsystem=golang
        cd _build && go test -vet=off -v -p 4 github.com/ianbruene/go-difflib/difflib github.com/ianbruene/go-difflib/difflib/bytes github.com/ianbruene/go-difflib/difflib/tester
unexpected directory layout:
        import path: _/<<PKGBUILDDIR>>/_build/src/github.com/ianbruene/go-difflib/difflib/tester
        root: /<<PKGBUILDDIR>>/_build/src
        dir: /<<PKGBUILDDIR>>/_build/src/github.com/ianbruene/go-difflib/difflib/tester
        expand root: /<<PKGBUILDDIR>>/_build
        expand dir: /<<PKGBUILDDIR>>/_build/src/github.com/ianbruene/go-difflib/difflib/tester
        separator: /
unexpected directory layout:
        import path: _/<<PKGBUILDDIR>>/_build/src/github.com/ianbruene/go-difflib/difflib/tester
        root: /<<PKGBUILDDIR>>/_build/src
        dir: /<<PKGBUILDDIR>>/_build/src/github.com/ianbruene/go-difflib/difflib/tester
        expand root: /<<PKGBUILDDIR>>/_build
        expand dir: /<<PKGBUILDDIR>>/_build/src/github.com/ianbruene/go-difflib/difflib/tester
        separator: /
dh_auto_test: error: cd _build && go test -vet=off -v -p 4 github.com/ianbruene/go-difflib/difflib github.com/ianbruene/go-difflib/difflib/bytes github.com/ianbruene/go-difflib/difflib/tester returned exit code 1
```

I've already applied the patch for the Debian package (see https://salsa.debian.org/go-team/packages/golang-github-ianbruene-go-difflib/-/blob/debian/sid/debian/patches/01-fix-unexpected-directory-layout-error-during-go-test.patch) so it is OK on the Debian side.

Please feel free to merge this PR or not depending on your preference on relative import paths vs. full paths.
(I was reading the debate at https://github.com/golang/go/issues/20883 and realized both sides have good arguments...)

Many thanks!

Cheers,
Anthony

