### PR TITLE
Improve for modern Go versions

### DIFF
--- a/difflib/bytes/bytes.go
+++ b/difflib/bytes/bytes.go
@@ -20,10 +20,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"hash/adler32"
 	"io"
 	"strings"
 	"unicode"
-	"hash/adler32"
 )
 
 func min(a, b int) int {
@@ -50,7 +50,7 @@ func calculateRatio(matches, length int) float64 {
 func listifyString(str []byte) (lst [][]byte) {
 	lst = make([][]byte, len(str))
 	for i := range str {
-		lst[i] = str[i:i+1]
+		lst[i] = str[i : i+1]
 	}
 	return lst
 }
@@ -80,20 +80,21 @@ func _hash(line []byte) lineHash {
 // store copies of the lines.
 // It needs to hold a reference to the underlying slice of lines.
 type B2J struct {
-	store map[lineHash] [][]int
-	b [][]byte
+	store map[lineHash][][]int
+	b     [][]byte
 }
 
 type lineType int8
+
 const (
-	lineNONE    lineType =  0
-	lineNORMAL  lineType =  1
+	lineNONE    lineType = 0
+	lineNORMAL  lineType = 1
 	lineJUNK    lineType = -1
 	linePOPULAR lineType = -2
 )
 
 func (b2j *B2J) _find(line *[]byte) (h lineHash, slotIndex int,
-                                     slot []int, lt lineType) {
+	slot []int, lt lineType) {
 	h = _hash(*line)
 	for slotIndex, slot = range b2j.store[h] {
 		// Thanks to the qualities of sha1, the probability of having more than
@@ -119,8 +120,8 @@ func (b2j *B2J) _find(line *[]byte) (h lineHash, slotIndex int,
 	return
 }
 
-func newB2J (b [][]byte, isJunk func([]byte) bool, autoJunk bool) *B2J {
-	b2j := B2J{store: map[lineHash] [][]int{}, b: b}
+func newB2J(b [][]byte, isJunk func([]byte) bool, autoJunk bool) *B2J {
+	b2j := B2J{store: map[lineHash][][]int{}, b: b}
 	ntest := len(b)
 	if autoJunk && ntest >= 200 {
 		ntest = ntest/100 + 1
@@ -258,12 +259,15 @@ func (m *SequenceMatcher) chainB() {
 // If IsJunk is not defined:
 //
 // Return (i,j,k) such that a[i:i+k] is equal to b[j:j+k], where
-//     alo <= i <= i+k <= ahi
-//     blo <= j <= j+k <= bhi
+//
+//	alo <= i <= i+k <= ahi
+//	blo <= j <= j+k <= bhi
+//
 // and for all (i',j',k') meeting those conditions,
-//     k >= k'
-//     i <= i'
-//     and if i == i', j <= j'
+//
+//	k >= k'
+//	i <= i'
+//	and if i == i', j <= j'
 //
 // In other words, of all maximal matching blocks, return one that
 // starts earliest in a, and of all those maximal matching blocks that
@@ -625,7 +629,7 @@ func NewDiffer() *Differ {
 
 var MINUS = []byte("-")
 var SPACE = []byte(" ")
-var PLUS  = []byte("+")
+var PLUS = []byte("+")
 var CARET = []byte("^")
 
 func (d *Differ) Compare(a [][]byte, b [][]byte) (diffs [][]byte, err error) {
@@ -665,7 +669,7 @@ func (d *Differ) StructuredDump(tag byte, x [][]byte, low int, high int) (out []
 	size := high - low
 	out = make([]DiffLine, size)
 	for i := 0; i < size; i++ {
-		out[i] = NewDiffLine(tag, x[i + low])
+		out[i] = NewDiffLine(tag, x[i+low])
 	}
 	return out
 }
@@ -835,7 +839,7 @@ func (d *Differ) QFormat(aline []byte, bline []byte, atags []byte, btags []byte)
 
 	out = [][]byte{append([]byte("- "), aline...)}
 	if len(atags) > 0 {
-		t := make([]byte, 0, len(atags) + common + 3)
+		t := make([]byte, 0, len(atags)+common+3)
 		t = append(t, []byte("? ")...)
 		for i := 0; i < common; i++ {
 			t = append(t, byte('\t'))
@@ -846,7 +850,7 @@ func (d *Differ) QFormat(aline []byte, bline []byte, atags []byte, btags []byte)
 	}
 	out = append(out, append([]byte("+ "), bline...))
 	if len(btags) > 0 {
-		t := make([]byte, 0, len(btags) + common + 3)
+		t := make([]byte, 0, len(btags)+common+3)
 		t = append(t, []byte("? ")...)
 		for i := 0; i < common; i++ {
 			t = append(t, byte('\t'))

--- a/difflib/bytes/bytes_test.go
+++ b/difflib/bytes/bytes_test.go
@@ -50,7 +50,7 @@ func bytesToStrings(in ...[]byte) (out []string) {
 	return
 }
 
-func TestlistifyString(t *testing.T) {
+func TestListifyString(t *testing.T) {
 	lst := listifyString([]byte("qwerty"))
 	if reflect.DeepEqual(lst, splitChars("qwerty")) != true {
 		t.Fatal("listifyString failure:", lst)
@@ -129,7 +129,7 @@ group
 	}
 }
 
-func ExampleGetUnifiedDiffCode() {
+func ExampleGetUnifiedDiffString() {
 	a := `one
 two
 three
@@ -162,7 +162,7 @@ four`
 	// -fmt.Printf("%s,%T",a,b)
 }
 
-func ExampleGetContextDiffCode() {
+func ExampleGetContextDiffString() {
 	a := `one
 two
 three
@@ -199,7 +199,7 @@ four`
 	//   four
 }
 
-func ExampleGetContextDiffString() {
+func ExampleGetContextDiffString_plain() {
 	a := `one
 two
 three
@@ -217,7 +217,7 @@ four`
 		Eol:      []byte{'\n'},
 	}
 	result, _ := GetContextDiffString(diff)
-	fmt.Printf(strings.Replace(string(result), "\t", " ", -1))
+	fmt.Print(strings.Replace(string(result), "\t", " ", -1))
 	// Output:
 	// *** Original
 	// --- Current

--- a/difflib/bytes/bytes_test.go
+++ b/difflib/bytes/bytes_test.go
@@ -6,9 +6,10 @@ import (
 	"math"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
-	"sort"
+
 	"../tester"
 )
 
@@ -35,7 +36,7 @@ func splitChars(s string) [][]byte {
 
 func stringsToBytes(in ...string) (out [][]byte) {
 	out = make([][]byte, len(in))
-	for i, s := range(in) {
+	for i, s := range in {
 		out[i] = []byte(s)
 	}
 	return
@@ -43,7 +44,7 @@ func stringsToBytes(in ...string) (out [][]byte) {
 
 func bytesToStrings(in ...[]byte) (out []string) {
 	out = make([]string, len(in))
-	for i, s := range(in) {
+	for i, s := range in {
 		out[i] = string(s)
 	}
 	return
@@ -332,7 +333,7 @@ func TestOutputFormatRangeFormatUnified(t *testing.T) {
 	// If a range is empty, its beginning line number shall be the number of
 	// the line just before the range, or 0 if the empty range starts the file.
 	fmt := formatRangeUnified
-	fm := func (a, b int) string { return string(fmt(a,b)) }
+	fm := func(a, b int) string { return string(fmt(a, b)) }
 	assertEqual(t, fm(3, 3), "3,0")
 	assertEqual(t, fm(3, 4), "4")
 	assertEqual(t, fm(3, 5), "4,2")
@@ -357,7 +358,7 @@ func TestOutputFormatRangeFormatContext(t *testing.T) {
 	// and the following format otherwise:
 	//     "--- %d ----\n", <ending line number>
 	fmt := formatRangeContext
-	fm := func (a, b int) string { return string(fmt(a,b)) }
+	fm := func(a, b int) string { return string(fmt(a, b)) }
 	assertEqual(t, fm(3, 3), "3")
 	assertEqual(t, fm(3, 4), "4")
 	assertEqual(t, fm(3, 5), "4,5")
@@ -476,7 +477,7 @@ func BenchmarkSplitLines10000(b *testing.B) {
 
 func prepareFilesToDiff(count, seed int) (As, Bs [][][]byte) {
 	defer runtime.GC()
-	aux := func () { // to ensure temp variables go out of scope
+	aux := func() { // to ensure temp variables go out of scope
 		stringsA, stringsB := tester.PrepareStringsToDiff(count, seed)
 		As = make([][][]byte, len(stringsA))
 		Bs = make([][][]byte, len(stringsB))
@@ -547,7 +548,7 @@ func TestDifferStructuredDump(t *testing.T) {
 		stringsToBytes("foo", "bar", "baz", "quux", "qwerty"),
 		1, 3)
 	expected := []DiffLine{DiffLine{'+', []byte("bar")},
-							DiffLine{'+', []byte("baz")}}
+		DiffLine{'+', []byte("baz")}}
 	if !reflect.DeepEqual(out, expected) {
 		t.Fatal("Differ StructuredDump failure:", out)
 	}
@@ -661,7 +662,7 @@ func TestGetUnifiedDiffString(t *testing.T) {
 	// Build diff
 	diff := UnifiedDiff{A: SplitLines(A),
 		FromFile: "file", FromDate: "then",
-		B: SplitLines(B),
+		B:      SplitLines(B),
 		ToFile: "tile", ToDate: "now", Eol: []byte{}, Context: 1}
 	// Run test
 	diffStr, err := GetUnifiedDiffString(diff)

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -198,12 +198,15 @@ func (m *SequenceMatcher) isBJunk(s string) bool {
 // If IsJunk is not defined:
 //
 // Return (i,j,k) such that a[i:i+k] is equal to b[j:j+k], where
-//     alo <= i <= i+k <= ahi
-//     blo <= j <= j+k <= bhi
+//
+//	alo <= i <= i+k <= ahi
+//	blo <= j <= j+k <= bhi
+//
 // and for all (i',j',k') meeting those conditions,
-//     k >= k'
-//     i <= i'
-//     and if i == i', j <= j'
+//
+//	k >= k'
+//	i <= i'
+//	and if i == i', j <= j'
 //
 // In other words, of all maximal matching blocks, return one that
 // starts earliest in a, and of all those maximal matching blocks that
@@ -595,7 +598,7 @@ func (d *Differ) StructuredDump(tag byte, x []string, low int, high int) (out []
 	size := high - low
 	out = make([]DiffLine, size)
 	for i := 0; i < size; i++ {
-		out[i] = NewDiffLine(tag, x[i + low])
+		out[i] = NewDiffLine(tag, x[i+low])
 	}
 	return out
 }
@@ -792,16 +795,16 @@ func formatRangeUnified(start, stop int) string {
 
 // Unified diff parameters
 type LineDiffParams struct {
-	A        []string             // First sequence lines
-	FromFile string               // First file name
-	FromDate string               // First file time
-	B        []string             // Second sequence lines
-	ToFile   string               // Second file name
-	ToDate   string               // Second file time
-	Eol      string               // Headers end of line, defaults to LF
-	Context  int                  // Number of context lines
-	AutoJunk bool                 // If true, use autojunking
-	IsJunkLine func(string)bool   // How to spot junk lines
+	A          []string          // First sequence lines
+	FromFile   string            // First file name
+	FromDate   string            // First file time
+	B          []string          // Second sequence lines
+	ToFile     string            // Second file name
+	ToDate     string            // Second file time
+	Eol        string            // Headers end of line, defaults to LF
+	Context    int               // Number of context lines
+	AutoJunk   bool              // If true, use autojunking
+	IsJunkLine func(string) bool // How to spot junk lines
 }
 
 // Compare two sequences of lines; generate the delta as a unified diff.

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -33,7 +33,7 @@ func splitChars(s string) []string {
 	return chars
 }
 
-func TestlistifyString(t *testing.T) {
+func TestListifyString(t *testing.T) {
 	lst := listifyString("qwerty")
 	if reflect.DeepEqual(lst, []string{"q", "w", "e", "r", "t", "y"}) != true {
 		t.Fatal("listifyString failure:", lst)
@@ -112,7 +112,7 @@ group
 	}
 }
 
-func ExampleGetUnifiedDiffCode() {
+func ExampleGetUnifiedDiffString() {
 	a := `one
 two
 three
@@ -145,7 +145,7 @@ four`
 	// -fmt.Printf("%s,%T",a,b)
 }
 
-func ExampleGetContextDiffCode() {
+func ExampleGetContextDiffString() {
 	a := `one
 two
 three
@@ -182,7 +182,7 @@ four`
 	//   four
 }
 
-func ExampleGetContextDiffString() {
+func ExampleGetContextDiffString_plain() {
 	a := `one
 two
 three
@@ -200,7 +200,7 @@ four`
 		Eol:      "\n",
 	}
 	result, _ := GetContextDiffString(diff)
-	fmt.Printf(strings.Replace(result, "\t", " ", -1))
+	fmt.Print(strings.Replace(result, "\t", " ", -1))
 	// Output:
 	// *** Original
 	// --- Current

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
 	"./tester"
 )
 
@@ -602,7 +603,7 @@ func TestGetUnifiedDiffString(t *testing.T) {
 	// Build diff
 	diff := LineDiffParams{A: SplitLines(A),
 		FromFile: "file", FromDate: "then",
-		B: SplitLines(B),
+		B:      SplitLines(B),
 		ToFile: "tile", ToDate: "now", Eol: "", Context: 1}
 	// Run test
 	diffStr, err := GetUnifiedDiffString(diff)

--- a/difflib/tester/tester.go
+++ b/difflib/tester/tester.go
@@ -35,20 +35,21 @@ func prepareStrings(seed int64) (A, B []string) {
 		}
 	}
 	// Do some copies from A to B
-	maxcopy := rand.Intn(len(A)-1)+1
+	maxcopy := rand.Intn(len(A)-1) + 1
+
 	for copied, tocopy := 0, rand.Intn(2*len(A)/3); copied < tocopy; {
-		l := rand.Intn(rand.Intn(maxcopy-1)+1)
-		for a,b,n := rand.Intn(len(A)), rand.Intn(len(B)), 0;
-		           a < len(A) && b < len(B) && n < l; a,b,n = a+1,b+1,n+1 {
+		l := rand.Intn(rand.Intn(maxcopy-1) + 1)
+		aRand, bRand := rand.Intn(len(A)), rand.Intn(len(B))
+		for a, b, n := aRand, bRand, 0; a < len(A) && b < len(B) && n < l; a, b, n = a+1, b+1, n+1 {
 			B[b] = A[a]
 			copied++
 		}
 	}
 	// And some from B to A
 	for copied, tocopy := 0, rand.Intn(2*len(A)/3); copied < tocopy; {
-		l := rand.Intn(rand.Intn(maxcopy-1)+1)
-		for a,b,n := rand.Intn(len(A)), rand.Intn(len(B)), 0;
-		           a < len(A) && b < len(B) && n < l; a,b,n = a+1,b+1,n+1 {
+		l := rand.Intn(rand.Intn(maxcopy-1) + 1)
+		aRand, bRand := rand.Intn(len(A)), rand.Intn(len(B))
+		for a, b, n := aRand, bRand, 0; a < len(A) && b < len(B) && n < l; a, b, n = a+1, b+1, n+1 {
 			A[a] = B[b]
 			copied++
 		}
@@ -60,7 +61,7 @@ func PrepareStringsToDiff(count, seed int) (As, Bs [][]string) {
 	As = make([][]string, count)
 	Bs = make([][]string, count)
 	for i := range As {
-		As[i], Bs[i] = prepareStrings(int64(i+seed))
+		As[i], Bs[i] = prepareStrings(int64(i + seed))
 	}
 	return
 }


### PR DESCRIPTION
This PR addresses two issues:

- Project sources were not formatted properly with `go fmt`.
All sources are processed to provide proper code formatting.

- Tests were broken for modern Go versions:
```
github.com/ianbruene/go-difflib/difflib
# github.com/ianbruene/go-difflib/difflib
# [github.com/ianbruene/go-difflib/difflib]
./difflib_test.go:202:13: non-constant format string in call to fmt.Printf
./difflib_test.go:35:6: TestlistifyString has malformed name: first letter after 'Test' must not be lowercase
./difflib_test.go:114:1: ExampleGetUnifiedDiffCode refers to unknown identifier: GetUnifiedDiffCode
./difflib_test.go:147:1: ExampleGetContextDiffCode refers to unknown identifier: GetContextDiffCode
FAIL	github.com/ianbruene/go-difflib/difflib [build failed]
...
./difflib/bytes/bytes_test.go:220:13: non-constant format string in call to fmt.Printf
./difflib/difflib_test.go:203:13: non-constant format string in call to fmt.Printf
```
Tests are fixed to satisfy modern `go vet` versions.